### PR TITLE
feat: add XDC (chain 50) vault and market

### DIFF
--- a/chains/50/markets/0x78ca1986ad5206cb3957198aacd06f8203d80b33dd19fbdfa99cfca5addce4f5/data.json
+++ b/chains/50/markets/0x78ca1986ad5206cb3957198aacd06f8203d80b33dd19fbdfa99cfca5addce4f5/data.json
@@ -1,0 +1,11 @@
+{
+  "chainId": 50,
+  "marketId": "0x78ca1986ad5206cb3957198aacd06f8203d80b33dd19fbdfa99cfca5addce4f5",
+  "collateralTokenAddress": "0x951857744785e80e2de051c32ee7b25f9c458c42",
+  "loanTokenAddress": "0xfa2958cb79b0491cc627c1557f441ef849ca8eb1",
+  "oracleAddress": "0x6ad93a3aa829514473d3df67382894a76c7283b4",
+  "irmAddress": "0x15c7312b0f26aa0aa70b24a0d2af87b9e7d614a0",
+  "lltvPercent": "625000000000000000",
+  "liquidationPenalty": "1126760563380281690",
+  "enabled": true
+}

--- a/chains/50/vaults/0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5/data.json
+++ b/chains/50/vaults/0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5/data.json
@@ -1,0 +1,10 @@
+{
+  "chainId": 50,
+  "name": "",
+  "tokenAddress": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+  "performanceFeePercentage": "0",
+  "vaultAddress": "0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5",
+  "curatorAddress": "0x2c38722DdB0faB52396c6486C85Ec1d19B6eEb89",
+  "enabled": true,
+  "version": 2
+}

--- a/chains/50/vaults/0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5/data.json
+++ b/chains/50/vaults/0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5/data.json
@@ -1,6 +1,6 @@
 {
   "chainId": 50,
-  "name": "",
+  "name": "testUSDC",
   "tokenAddress": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
   "performanceFeePercentage": "0",
   "vaultAddress": "0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5",

--- a/public/masterlist.json
+++ b/public/masterlist.json
@@ -5948,6 +5948,36 @@
       "rewards": [],
       "blacklist": []
     },
+    "50": {
+      "vaults": [],
+      "vaultsV2": [
+        {
+          "chainId": 50,
+          "name": "",
+          "tokenAddress": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+          "performanceFeePercentage": "0",
+          "vaultAddress": "0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5",
+          "curatorAddress": "0x2c38722DdB0faB52396c6486C85Ec1d19B6eEb89",
+          "enabled": true,
+          "version": 2
+        }
+      ],
+      "markets": [
+        {
+          "chainId": 50,
+          "marketId": "0x78ca1986ad5206cb3957198aacd06f8203d80b33dd19fbdfa99cfca5addce4f5",
+          "collateralTokenAddress": "0x951857744785e80e2de051c32ee7b25f9c458c42",
+          "loanTokenAddress": "0xfa2958cb79b0491cc627c1557f441ef849ca8eb1",
+          "oracleAddress": "0x6ad93a3aa829514473d3df67382894a76c7283b4",
+          "irmAddress": "0x15c7312b0f26aa0aa70b24a0d2af87b9e7d614a0",
+          "lltvPercent": "625000000000000000",
+          "liquidationPenalty": "1126760563380281690",
+          "enabled": true
+        }
+      ],
+      "rewards": [],
+      "blacklist": []
+    },
     "137": {
       "vaults": [
         {

--- a/public/masterlist.json
+++ b/public/masterlist.json
@@ -5953,7 +5953,7 @@
       "vaultsV2": [
         {
           "chainId": 50,
-          "name": "",
+          "name": "testUSDC",
           "tokenAddress": "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
           "performanceFeePercentage": "0",
           "vaultAddress": "0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5",


### PR DESCRIPTION
Adds the following to XDC chain (50):

**Vault (V2):** `0x223D1Ebf4A893F4D7c7f18bB172585173A5B07d5`
- Asset: USDC (`0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1`)
- Curator: `0x2c38722DdB0faB52396c6486C85Ec1d19B6eEb89`

**Market:** `0x78ca1986ad5206cb3957198aacd06f8203d80b33dd19fbdfa99cfca5addce4f5`
- Collateral: WXDC (`0x951857744785E80e2De051c32EE7b25f9c458C42`)
- Loan Token: USDC (`0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1`)
- Oracle: `0x6Ad93a3aA829514473D3DF67382894A76c7283B4`
- IRM: `0x15c7312B0f26aa0AA70B24a0D2AF87B9e7D614A0`
- LLTV: 62.5%
- Liquidation Penalty: 1.126760563380281690

Compiled masterlist.json updated.