### PR TITLE
feat: add Gensyn market

### DIFF
--- a/chains/685689/markets/0x2060939a4695812f8565bee3a38ec693a95f9f6a57bc81d2693d48116d38f702/data.json
+++ b/chains/685689/markets/0x2060939a4695812f8565bee3a38ec693a95f9f6a57bc81d2693d48116d38f702/data.json
@@ -1,0 +1,11 @@
+{
+  "chainId": 685689,
+  "marketId": "0x2060939a4695812f8565bee3a38ec693a95f9f6a57bc81d2693d48116d38f702",
+  "collateralTokenAddress": "0x4e742319f6b0fec4afa504fc8ed3ceab0fb751a2",
+  "loanTokenAddress": "0x5b32c997211621d55a89cc5abaf1cc21f3a6ddf5",
+  "oracleAddress": "0x11fbe2368c913c462771e255623bc4b820ce4f5e",
+  "irmAddress": "0x549effae58f9db253aaf60fbcec8b4cb74a952a8",
+  "lltvPercent": "625000000000000000",
+  "liquidationPenalty": "1126760563380281690",
+  "enabled": true
+}

--- a/public/masterlist.json
+++ b/public/masterlist.json
@@ -8968,6 +8968,17 @@
       "markets": [
         {
           "chainId": 685689,
+          "marketId": "0x2060939a4695812f8565bee3a38ec693a95f9f6a57bc81d2693d48116d38f702",
+          "collateralTokenAddress": "0x4e742319f6b0fec4afa504fc8ed3ceab0fb751a2",
+          "loanTokenAddress": "0x5b32c997211621d55a89cc5abaf1cc21f3a6ddf5",
+          "oracleAddress": "0x11fbe2368c913c462771e255623bc4b820ce4f5e",
+          "irmAddress": "0x549effae58f9db253aaf60fbcec8b4cb74a952a8",
+          "lltvPercent": "625000000000000000",
+          "liquidationPenalty": "1126760563380281690",
+          "enabled": true
+        },
+        {
+          "chainId": 685689,
           "marketId": "0xd118206de86982b6823750ff31b900ce569110ec0394c5787bd061b2c8a78d6d",
           "collateralTokenAddress": "0x4200000000000000000000000000000000000006",
           "loanTokenAddress": "0x5b32c997211621d55a89cc5abaf1cc21f3a6ddf5",


### PR DESCRIPTION
Adds market to Gensyn chain (685689):

**Market:** `0x2060939a4695812f8565bee3a38ec693a95f9f6a57bc81d2693d48116d38f702`
- Collateral: `0x4e742319f6b0FeC4afA504fC8ED3cEAB0fb751A2`
- Loan Token: `0x5b32c997211621d55a89Cc5abAF1cC21F3A6ddF5`
- Oracle: `0x11FbE2368c913c462771e255623bC4B820Ce4F5E`
- IRM: `0x549EFFAE58F9Db253AAF60fbCeC8B4cB74a952A8`
- LLTV: 62.5%
- Liquidation Penalty: 1.126760563380281690

Compiled masterlist.json updated.