### PR TITLE
fix: update 0G vault names to match on-chain values

### DIFF
--- a/chains/16661/vaults/0x6003EEe8e9E8b7C72149B16cd88DEA6eeB4681E3/data.json
+++ b/chains/16661/vaults/0x6003EEe8e9E8b7C72149B16cd88DEA6eeB4681E3/data.json
@@ -1,6 +1,6 @@
 {
   "chainId": 16661,
-  "name": "0g USDC Vault",
+  "name": "AlphaGrowth USDC",
   "tokenAddress": "0x1f3AA82227281cA364bFb3d253B0f1af1Da6473E",
   "performanceFeePercentage": "0",
   "vaultAddress": "0x6003EEe8e9E8b7C72149B16cd88DEA6eeB4681E3",

--- a/chains/16661/vaults/0xe29AA6Cd4C2245f7Eb52386E28D82Fc0DE2c32dC/data.json
+++ b/chains/16661/vaults/0xe29AA6Cd4C2245f7Eb52386E28D82Fc0DE2c32dC/data.json
@@ -1,6 +1,6 @@
 {
   "chainId": 16661,
-  "name": "w0g Vault",
+  "name": "AlphaGrowth W0G",
   "tokenAddress": "0x1Cd0690fF9a693f5EF2dD976660a8dAFc81A109c",
   "performanceFeePercentage": "0",
   "vaultAddress": "0xe29AA6Cd4C2245f7Eb52386E28D82Fc0DE2c32dC",


### PR DESCRIPTION
Updates the 0G (chain 16661) vault names to their actual on-chain names read from the contracts:

- **0x6003...8E3**: '0g USDC Vault' → **'AlphaGrowth USDC'** (on-chain: `AlphaGrowth USDC`, symbol: `0gUSDC.e`)
- **0xe29A...2dC**: 'w0gVault' → **'AlphaGrowth W0G'** (on-chain: `AlphaGrowth W0G`, symbol: `0gw0g`)