### PR TITLE
feat: add USDC Vault (mmUSDC) on Pharos Mainnet

### DIFF
--- a/chains/1672/vaults/0x047cD0a91E9B92ED979189a6C8A120bf280f02E5/data.json
+++ b/chains/1672/vaults/0x047cD0a91E9B92ED979189a6C8A120bf280f02E5/data.json
@@ -1,0 +1,10 @@
+{
+  "chainId": 1672,
+  "name": "USDC Vault",
+  "tokenAddress": "0xC879C018dB60520F4355C26eD1a6D572cdAC1815",
+  "performanceFeePercentage": "0",
+  "vaultAddress": "0x047cD0a91E9B92ED979189a6C8A120bf280f02E5",
+  "guardianAddress": "0x0000000000000000000000000000000000000000",
+  "curatorAddress": "0x8747Cf054EfE02ECd4A7A31eB2030cefEB49d846",
+  "enabled": true
+}


### PR DESCRIPTION
Adds the USDC Vault on Pharos Mainnet (chain 1672).

**Vault:** `0x047cD0a91E9B92ED979189a6C8A120bf280f02E5`
**On-chain name:** USDC Vault
**Symbol:** mmUSDC
**Asset:** `0xC879C018dB60520F4355C26eD1a6D572cdAC1815`
**Curator:** `0x8747Cf054EfE02ECd4A7A31eB2030cefEB49d846`

V1 vault (MetaMorpho). Data read directly from the Pharos RPC (`https://rpc.pharos.xyz`).