### PR TITLE
feat: add Pharos USDC market

### DIFF
--- a/chains/1672/markets/0xbea21c372be9729760844cb2d60879f5ced6a8a5bba9a538dea8801e8ac49e73/data.json
+++ b/chains/1672/markets/0xbea21c372be9729760844cb2d60879f5ced6a8a5bba9a538dea8801e8ac49e73/data.json
@@ -1,0 +1,11 @@
+{
+  "chainId": 1672,
+  "marketId": "0xbea21c372be9729760844cb2d60879f5ced6a8a5bba9a538dea8801e8ac49e73",
+  "collateralTokenAddress": "0x4809010926aec940b550d34a46a52739f996d75d",
+  "loanTokenAddress": "0xc879c018db60520f4355c26ed1a6d572cdac1815",
+  "oracleAddress": "0x9416f861970c2a39c02ab7696ef0496383d4e81b",
+  "irmAddress": "0xd5e02889c13230458506cc842347c4e62f8cdf3a",
+  "lltvPercent": "915000000000000000",
+  "liquidationPenalty": "1026167265264238070",
+  "enabled": true
+}

--- a/public/masterlist.json
+++ b/public/masterlist.json
@@ -6806,7 +6806,19 @@
           "version": 2
         }
       ],
-      "markets": [],
+      "markets": [
+        {
+          "chainId": 1672,
+          "marketId": "0xbea21c372be9729760844cb2d60879f5ced6a8a5bba9a538dea8801e8ac49e73",
+          "collateralTokenAddress": "0x4809010926aec940b550d34a46a52739f996d75d",
+          "loanTokenAddress": "0xc879c018db60520f4355c26ed1a6d572cdac1815",
+          "oracleAddress": "0x9416f861970c2a39c02ab7696ef0496383d4e81b",
+          "irmAddress": "0xd5e02889c13230458506cc842347c4e62f8cdf3a",
+          "lltvPercent": "915000000000000000",
+          "liquidationPenalty": "1026167265264238070",
+          "enabled": true
+        }
+      ],
       "rewards": [],
       "blacklist": []
     },


### PR DESCRIPTION
Adds Morpho market `0xbea21c372be9729760844cb2d60879f5ced6a8a5bba9a538dea8801e8ac49e73` on Pharos (chain 1672).

**Market details:**
- Loan token: USDC (`0xc879c018db60520f4355c26ed1a6d572cdac1815`)
- Collateral token: `0x4809010926aec940b550d34a46a52739f996d75d`
- Oracle: `0x9416f861970c2a39c02ab7696ef0496383d4e81b`
- IRM: `0xd5e02889c13230458506cc842347c4e62f8cdf3a`
- LLTV: 91.5%
- LIF: ~1.026 (computed from LLTV)